### PR TITLE
Fix issue with error handling

### DIFF
--- a/recaptcha.cfc
+++ b/recaptcha.cfc
@@ -73,7 +73,7 @@ component {
 				if( structKeyExists( out.json, "error-codes" ) ) {
 					out.error= out.json[ "error-codes" ];
 					if( isArray( out.error ) ) {
-						out.error= listToArray( out.error, " " );
+						out.error = arrayToList( out.error, " " );
 					}
 				}
 			} catch (any cfcatch) {


### PR DESCRIPTION
It looks like the desired output in the error field is a list of errors from the json 'error-codes' array, however it was using 'listToArray' after checking the value was an array - thus it would throw an error.